### PR TITLE
Fix skipExistingHeaders on long files without headers yet

### DIFF
--- a/src/main/groovy/org/cadixdev/gradle/licenser/util/HeaderHelper.java
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/util/HeaderHelper.java
@@ -113,7 +113,10 @@ public final class HeaderHelper {
                 break;
             }
             // If the current line doesn't match and there's no end marker, assume the header is complete
-            contentLinesMatch = contentLinesMatch && (line.startsWith(format.getPrefix()) || format.getEnd() == null);
+            if (!line.startsWith(format.getPrefix()) && format.getEnd() != null) {
+                contentLinesMatch = false;
+                break;
+            }
         }
 
         return firstLineMatches && contentLinesMatch && lastLineMatches;


### PR DESCRIPTION
The problem is that in `PreparedCommentHeader` there is a `reader.mark(2048)` call but the `contentStartsWithValidHeaderFormat` check can use a lot more than 2048 since it scans the entire file. Prevent this by stopping the scan once `contentLinesMatch` is false.

Upstream PR: https://github.com/CadixDev/licenser/pull/41.